### PR TITLE
make legal squares semi-transparent and correct their dimensions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,8 @@
 #define screenHeight 1000
 #define squareWidth 125
 
+#define TRANSPARENT_RED Color{ 230, 41, 55, 100 }
+
 using namespace std;
 
 int main() {
@@ -69,7 +71,7 @@ int main() {
                     Square* square = sq_vec[i];
                     int posX = square->x;
                     int posY = square->y;
-                    DrawRectangle(posX, posY, squareWidth-1, squareWidth-1, RED);
+                    DrawRectangle(posX, posY, squareWidth, squareWidth, TRANSPARENT_RED);
                 }
                 DrawTexture(temp_piece.image, x-60, y-60, WHITE);
             }


### PR DESCRIPTION
I found legal squares not being semi-transparent and not taking the full square very annoying (OCD).
Make me famous (:
![Screenshot_10-Feb_21-33-53_11378](https://github.com/user-attachments/assets/59dd95f6-05d2-43fa-ad56-6eb68add2f03)
